### PR TITLE
Revert "Make shipped mail notification scripts working"

### DIFF
--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -59,7 +59,7 @@ RUN cd /check_postgres ;\
 
 FROM debian:buster-slim
 
-RUN ["/bin/bash", "-exo", "pipefail", "-c", "export DEBIAN_FRONTEND=noninteractive; apt-get update; apt-get install --no-install-{recommends,suggests} -y dumb-init libboost-{context,coroutine,date-time,filesystem,program-options,regex,system,thread}1.67 libedit2 libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 mailutils monitoring-plugins openssh-client openssl postfix; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
+RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; apt-get install --no-install-{recommends,suggests} -y dumb-init libboost-{context,coroutine,date-time,filesystem,program-options,regex,system,thread}1.67 libedit2 libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 monitoring-plugins openssh-client openssl; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
 
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint
 


### PR DESCRIPTION
This reverts commit 247ec715e758bc70671099e42947f3bb8e7c91f4.

That commit actually just silenced the not working mail notifications.