### PR TITLE
Add curl to the image to allow integration of scripts that use webhooks without modifying the base image.

### DIFF
--- a/deps.Dockerfile
+++ b/deps.Dockerfile
@@ -59,7 +59,7 @@ RUN cd /check_postgres ;\
 
 FROM debian:buster-slim
 
-RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install --no-install-{recommends,suggests} -y ca-certificates dumb-init libboost-{context,coroutine,date-time,filesystem,program-options,regex,system,thread}1.67 libedit2 libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 mailutils monitoring-plugins msmtp{,-mta} openssh-client openssl; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
+RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install --no-install-{recommends,suggests} -y ca-certificates curl dumb-init libboost-{context,coroutine,date-time,filesystem,program-options,regex,system,thread}1.67 libedit2 libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 mailutils monitoring-plugins msmtp{,-mta} openssh-client openssl; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
 
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint
 


### PR DESCRIPTION
I found that many scripts to trigger web hooks require curl.

For example to trigger a notification in Telegram, a curl comand like this is required:

/usr/bin/curl --silent --output /dev/null --data-urlencode chat_id=$chat_id --data-urlencode "text=$notification_text" --data-urlencode parse_mode=HTML --data-urlencode disable_web_page_preview=true https://api.telegram.org/$bot_id/sendMessage

Also the ca-certificates package was added, to allow validating certificates.
