### PR TITLE
Make `icinga2 --version` display the actual git version

### DIFF
--- a/action.bash
+++ b/action.bash
@@ -13,7 +13,7 @@ cache () {
 mkimg () {
 	test -n "$TAG"
 
-	node /actions/checkout/dist/index.js |grep -vFe ::add-matcher::
+	env INPUT_FETCH-DEPTH=0 node /actions/checkout/dist/index.js |grep -vFe ::add-matcher::
 	cache restore
 
 	mkdir -p ccache


### PR DESCRIPTION
By default, actions/checkout sets fetch-depth to 1, meaning it will not fetch enough information to use `git describe --tags` as used by our CMakeLists to determine the version number. Setting it to 0 means to fetch all history.

I'm note sure if this is the best way to pass that input, but I'm also not sure if that's actually the proper way to use that action.

### Test

I've pushed an extra branch that additionally prints the version during build (https://github.com/Icinga/docker-icinga2/tree/bugfix/git-version-debug) and added a branch in the icinga2 repo that uses this test branch (https://github.com/Icinga/icinga2/tree/bugfix/docker-git-version). The latest Docker image build of that branch shows the correct version.

fixes #69