### PR TITLE
Expose port 5665

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,5 +77,6 @@ COPY icinga2-bin/ /
 RUN ["install", "-o", "icinga", "-g", "icinga", "-d", "/data"]
 RUN ["bash", "-exo", "pipefail", "-c", "for d in /etc/icinga2 /var/*/icinga2; do mkdir -p $(dirname /data-init$d); mv $d /data-init$d; ln -vs /data$d $d; done"]
 
+EXPOSE 5665
 USER icinga
 CMD ["icinga2", "daemon"]


### PR DESCRIPTION
That way, the port is automatically mapped when using the publish
all option and is automatically exposed when port mapping in the
SDK is used. This is also useful in terms of documentation.