### PR TITLE
Actually run tests

### DIFF
--- a/action.Dockerfile
+++ b/action.Dockerfile
@@ -30,7 +30,7 @@ ADD action-base.list /etc/apt/sources.list.d/misc.list
 RUN apt-get update ;\
 	apt-get install --no-install-{recommends,suggests} -y \
 		bison cmake docker-ce-cli flex g++ git \
-		libboost{,-{context,coroutine,date-time,filesystem,program-options,regex,system,thread}}1.74-dev \
+		libboost{,-{context,coroutine,date-time,filesystem,program-options,regex,system,test,thread}}1.74-dev \
 		libedit-dev libmariadb-dev libpq-dev libssl-dev make nodejs ;\
 	apt-get install --no-install-{recommends,suggests} -y ccache ;\
 	apt-get clean ;\


### PR DESCRIPTION
BoostTestTargets is somewhat strange and seems to just not build or run tests at all when the libboost-test-dev package is missing.

## Test

### Before

[GitHub Actions output from the last commit on master](https://github.com/Icinga/docker-icinga2/runs/4791813407?check_suite_focus=true#step:4:1648):
```
 + make test
Running tests...
Test project /i2cp/build
No tests were found!!!
```

### After

Let's see if the GitHub Actions output for this PR looks more promising. [Looks better indeed](https://github.com/Icinga/docker-icinga2/runs/5289123059?check_suite_focus=true#step:4:1710):
```
+ make test
Running tests...
Test project /i2cp/build
        Start   1: base-base_array/construct
  1/117 Test   #1: base-base_array/construct ...............................................   Passed    0.01 sec
[...]
```

fixes #67