### PR TITLE
Dockerfile: also install monitoring-plugins' recommendations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN rm -rf /icinga2-bin/usr/share/doc/icinga2/markdown
 
 FROM debian:bullseye-slim as icinga2
 
-RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; DEBIAN_FRONTEND=noninteractive apt-get install --no-install-{recommends,suggests} -y ca-certificates curl dumb-init libboost-{context,coroutine,date-time,filesystem,iostreams,program-options,regex,system,thread}1.74.0 libcap2-bin libedit2 libldap-common libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 mailutils monitoring-plugins msmtp{,-mta} openssh-client openssl; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
+RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-{recommends,suggests} -y ca-certificates curl dumb-init libboost-{context,coroutine,date-time,filesystem,iostreams,program-options,regex,system,thread}1.74.0 libcap2-bin libedit2 libldap-common libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 mailutils msmtp{,-mta} openssh-client openssl; apt-get install --no-install-suggests -y monitoring-plugins; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
 
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint
 


### PR DESCRIPTION
so that everything works as expected. Contra: +100MB/33% image size. New packages:

bind9-dnsutils bind9-host bind9-libs dbus dirmngr dnsutils gnupg gnupg-l10n gnupg-utils gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm libapparmor1 libarchive13 libassuan0 libavahi-client3 libavahi-common-data libavahi-common3 libcups2 libdbi1 libdbus-1-3 libfstrm0 libgpgme11 libjansson4 libjson-c5 libksba8 libldb2 liblmdb0 libmaxminddb0 libnet-snmp-perl libnpth0 libpci3 libpopt0 libprotobuf-c1 libpython3-stdlib libradcli4 libsensors-config libsensors5 libsmbclient libsnmp-base libsnmp40 libtalloc2 libtdb1 libtevent0 liburiparser1 libuv1 libwbclient0 libwrap0 libxml2 pci.ids pinentry-curses psmisc python3 python3-gpg python3-ldb python3-minimal python3-samba python3-talloc python3-tdb python3.9 python3.9-minimal rpcbind samba-common samba-common-bin samba-dsdb-modules samba-libs smbclient snmp sudo

Origin: https://github.com/Icinga/docker-icinga2/pull/83#issuecomment-1433039396

## Additional new packages with all packages' recommendations (+12MB)

* libb-hooks-endofscope-perl
* libclass-xsaccessor-perl
* libglib2.0-data
* libgpm2
* libmodule-implementation-perl
* libnamespace-clean-perl
* libpackage-stash-perl
* libpackage-stash-xs-perl
* libpam-cap
* libsasl2-modules
* libsecret-tools
* libsub-exporter-progressive-perl
* libsub-identify-perl
* libsub-name-perl
* libtry-tiny-perl
* libvariable-magic-perl
* libx11-6
* libx11-data
* libxau6
* libxcb1
* libxdmcp6
* libxext6
* libxmuu1
* netbase
* publicsuffix
* shared-mime-info
* xauth
* xdg-user-dirs