### PR TITLE
Run `apt-get update` in action.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout HEAD
         uses: actions/checkout@v1
 
+      - shell: bash
+        run: sudo apt-get update
+
       - name: QEMU
         run: sudo apt-get install -y qemu-user-static binfmt-support
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ runs:
     - uses: actions/checkout@v3
 
     - shell: bash
+      run: sudo apt-get update
+
+    - shell: bash
       run: sudo apt-get install -y qemu-user-static binfmt-support
 
     - shell: bash


### PR DESCRIPTION
GitHub does not so automatically so the package lists may be outdated, causing the package installation to fail:

    Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/universe amd64 qemu-user-static amd64 1:6.2+dfsg-2ubuntu6.7
      404  Not Found [IP: 52.147.219.192 80]
    E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_6.2%2bdfsg-2ubuntu6.7_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
    E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

This currently happens on [pipelines in the icinga2 repo](https://github.com/Icinga/icinga2/actions/runs/4859660612/jobs/8662552148).