### PR TITLE
Enable systemd integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update ;\
 	apt-get install --no-install-{recommends,suggests} -y \
 		bison cmake flex g++ git \
 		libboost{,-{context,coroutine,date-time,filesystem,iostreams,program-options,regex,system,test,thread}}1.74-dev \
-		libedit-dev libmariadb-dev libpq-dev libssl-dev make ;\
+		libedit-dev libmariadb-dev libpq-dev libssl-dev libsystemd-dev make ;\
 	apt-get install --no-install-{recommends,suggests} -y ccache ;\
 	apt-get clean ;\
 	rm -vrf /var/lib/apt/lists/*
@@ -79,7 +79,7 @@ RUN mkdir /icinga2-build
 WORKDIR /icinga2-build
 
 RUN PATH="/usr/lib/ccache:$PATH" cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_SYSCONFDIR=/etc \
-	-DCMAKE_INSTALL_LOCALSTATEDIR=/var -DICINGA2_RUNDIR=/run \
+	-DCMAKE_INSTALL_LOCALSTATEDIR=/var -DICINGA2_RUNDIR=/run -DUSE_SYSTEMD=ON \
 	-DICINGA2_SYSCONFIGFILE=/etc/sysconfig/icinga2 -DICINGA2_WITH_{COMPAT,LIVESTATUS}=OFF /icinga2-src
 
 RUN --mount=type=cache,target=/root/.ccache make
@@ -94,7 +94,7 @@ RUN rm -rf /icinga2-bin/usr/share/doc/icinga2/markdown
 
 FROM debian:bullseye-slim as icinga2
 
-RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-{recommends,suggests} -y ca-certificates curl dumb-init libboost-{context,coroutine,date-time,filesystem,iostreams,program-options,regex,system,thread}1.74.0 libcap2-bin libedit2 libldap-common libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 mailutils msmtp{,-mta} openssh-client openssl; apt-get install --no-install-suggests -y monitoring-plugins; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
+RUN ["/bin/bash", "-exo", "pipefail", "-c", "apt-get update; export DEBIAN_FRONTEND=noninteractive; apt-get install --no-install-{recommends,suggests} -y ca-certificates curl dumb-init libboost-{context,coroutine,date-time,filesystem,iostreams,program-options,regex,system,thread}1.74.0 libcap2-bin libedit2 libldap-common libmariadb3 libmoosex-role-timer-perl libpq5 libssl1.1 libsystemd0 mailutils msmtp{,-mta} openssh-client openssl; apt-get install --no-install-suggests -y monitoring-plugins; apt-get clean; rm -vrf /var/lib/apt/lists/*"]
 
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint
 


### PR DESCRIPTION
podman is able to pass systemd notification sockets through to the containerized application.
By enabling the systemd integration in icinga2 the host systemd is able to see the runtime status of the containerized icinga2 instance, especially for startup notifications.

libsystemd is already installed in the base image so no new runtime dependency is introduced.