### PR TITLE
build.bash: workaround a bug in docker buildx build CLI

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -25,7 +25,7 @@ if ! docker buildx version; then
 fi
 
 OUR_DIR="$(realpath "$(dirname "$0")")"
-COMMON_ARGS=(-t "icinga/icinga2:$TAG" --build-context "icinga2-git=$(realpath "$I2SRC")/.git" "$OUR_DIR")
+COMMON_ARGS=(-t "icinga/icinga2:$TAG" --build-context "icinga2-git=$(realpath "$I2SRC")/.git/" "$OUR_DIR")
 BUILDX=(docker buildx build --platform "$(cat "${OUR_DIR}/platforms.txt")")
 
 case "$ACTION" in


### PR DESCRIPTION
--build-context dirs seem to have to end with a / to be accepted.

This blocks:

* https://github.com/Icinga/icinga2/pull/9980
* https://github.com/Icinga/icinga2/pull/9981
* https://github.com/Icinga/icinga2/pull/9982