### PR TITLE
.github/dependabot.yml: Do not ignore github.com/otiai10/copy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: github.com/otiai10/copy
-    versions:
-    - 1.4.2
-    - 1.5.1
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
The dependabot.yml configuration file is in its same state as initially committed in #59. Since four years ago, the configuration contains an ignore rule for the github.com/otiai10/copy Go module, which thus have not received any updates.