### PR TITLE
GitHub actions: clone Icinga 2 support/2.15 branch, not master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - run: docker buildx create --use
 
       - name: Icinga 2
-        run: git clone https://github.com/Icinga/icinga2.git
+        run: git clone -b support/2.15 https://github.com/Icinga/icinga2.git
 
       - name: Build
         run: ./build.bash ./icinga2 all


### PR DESCRIPTION
to prevent GitHub action failures due to missing Protobuf.

Latter is not needed – this image is for Icinga 2.15.

closes #156